### PR TITLE
Add embedding-based duplicate detection for mentions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ streamlit
 plotly
 fastapi
 uvicorn
+sentence-transformers


### PR DESCRIPTION
## Summary
- Enhance deduplication by comparing mention quotes via sentence-transformer embeddings and cosine similarity
- Add sentence-transformers dependency

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*
- `python -m py_compile analyze_dialogs_advanced.py`


------
https://chatgpt.com/codex/tasks/task_e_68c70191428883288c5faa6174e1ad9b