### PR TITLE
Add Reload button to dashboard

### DIFF
--- a/simple_dashboard.py
+++ b/simple_dashboard.py
@@ -36,6 +36,9 @@ def load_stats() -> dict:
 
 # ---------- UI: sidebar ----------
 st.sidebar.header("Фильтры")
+reload_btn = st.sidebar.button("Reload")
+if reload_btn:
+    st.cache_data.clear()
 df = load_mentions()
 stats = load_stats()
 


### PR DESCRIPTION
## Summary
- add sidebar "Reload" button that clears Streamlit cache
- ensure cached stats and results are re-read when reloading

## Testing
- `python -m py_compile simple_dashboard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c701e7bc9c832898f99fe6401112de