### PR TITLE
Add safe OpenAI request handling

### DIFF
--- a/analyze_dialogs_advanced.py
+++ b/analyze_dialogs_advanced.py
@@ -115,20 +115,25 @@ class LLM:
                 {"role": "user", "content": user},
             ],
         }
-        r = self.client.post(
-            "https://api.openai.com/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {self.key}",
-                "Content-Type": "application/json",
-            },
-            json=payload,
-        )
-        r.raise_for_status()
-        content = r.json()["choices"][0]["message"]["content"]
         try:
+            r = self.client.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self.key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+            r.raise_for_status()
+        except httpx.RequestError as e:
+            print(f"[warn] OpenAI request failed for dialog {dialog_id}: {e}")
+            return []
+        try:
+            content = r.json()["choices"][0]["message"]["content"]
             js = json.loads(content)
             arr = js.get("mentions", [])
-        except Exception:
+        except (KeyError, ValueError, json.JSONDecodeError) as e:
+            print(f"[warn] Failed to parse response for dialog {dialog_id}: {e}")
             arr = []
         out = []
         for m in arr:


### PR DESCRIPTION
## Summary
- Guard OpenAI requests with httpx.RequestError handling to log warnings and continue
- Skip invalid model responses by wrapping json.loads in try/except

## Testing
- `python -m py_compile analyze_dialogs_advanced.py consolidate_and_summarize.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c701b6eccc8328a3963360a6969b97