### PR TITLE
feat: add progress bars and logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ streamlit
 plotly
 fastapi
 uvicorn
+tqdm


### PR DESCRIPTION
## Summary
- show progress over dialogs and windows using tqdm
- log mention counts and errors per dialog
- add tqdm dependency

## Testing
- `pytest`
- `python -m py_compile analyze_dialogs_advanced.py`


------
https://chatgpt.com/codex/tasks/task_e_68c70196b4448328b60d2397e34ff0f5